### PR TITLE
Add a rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.60"


### PR DESCRIPTION
Reasoning behind this suggestion:

UX:
  * It allows you to `git clone` and `cargo run` without having to set up a particular default toolchain. Using `stable` as the channel would also have this effect.

Reproducibility:
  * Documentation can be very confident that examples work (since the toolchain is known).
  * Issue reporters can share the commit of the code they're using and you can more exactly reproduce that version.

My thought process is usually something like: Either check in `Cargo.lock` and  a pinned `rust-toolchain.toml` or check in neither. If you're going to lock all your dependency versions, you might as well lock the toolchain too and get full reproducibility. If you don't want to lock the toolchain, you might as well not lock dependencies either and let each user build with the latest of both (within the constraint bounds).

Why not use `stable` channel instead of a fixed version? That would give you the UX benefit above but none of the other benefits. If you don't care about reproducibility at all, you could remove the `Cargo.lock` file and let the whole repo float on the dependency constraint solver only. That usually works better for libraries than for executables.

Does this add a maintenance burden? No more than having a `Cargo.lock` file does, hence the reasoning above.